### PR TITLE
[NFCI] Rename ambiguous use of Client.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -60,7 +60,7 @@ clean:
 @WITH_JAVA_WEBSOCKET_TRUE@ WEBSOCKET_SOURCES = \
 @WITH_JAVA_WEBSOCKET_TRUE@   org/domterm/websocket/DomServer.java
 @ENABLE_PTY_TRUE@          PTY_SOURCES = \
-@ENABLE_PTY_TRUE@             org/domterm/pty/PtyClient.java \
+@ENABLE_PTY_TRUE@             org/domterm/pty/PtyBackend.java \
 @ENABLE_PTY_TRUE@             org/domterm/pty/RunPty.java \
 @ENABLE_PTY_TRUE@             org/domterm/pty/PTY.java
 @WITH_JAVAFX_TRUE@         JAVAFX_SOURCES =\
@@ -75,9 +75,9 @@ DOMTERM_JAR_SOURCES = \
   $(WEBSOCKET_SOURCES) \
   $(PTY_SOURCES) \
   $(JAVAFX_SOURCES) \
-  org/domterm/Client.java \
-  org/domterm/ClassClient.java \
-  org/domterm/ProcessClient.java \
+  org/domterm/Backend.java \
+  org/domterm/ClassBackend.java \
+  org/domterm/ProcessBackend.java \
   org/domterm/util/DomTermErrorStream.java \
   org/domterm/util/StringBufferedWriter.java \
   org/domterm/util/Util.java \

--- a/doc/DomTerm.texi
+++ b/doc/DomTerm.texi
@@ -78,7 +78,7 @@ running in the stand-alone DomTerm application.
 @c The @emph is a dummy to force the @image inside a paragraph
 @emph{}
 @image{images/domterm-1}
-A client @strong{can ``print'' images, graphics, and rich text}.
+A back-end @strong{can ``print'' images, graphics, and rich text}.
 Handles Unicode.
 Here you can see ``printing'' HTML for images and rich text,
 from the @uref{http://www.gnu.org/software/kawa/,Kawa} REPL.
@@ -113,7 +113,7 @@ A terminal emulator.
 User @strong{preferences are controlled a CSS stylesheet},
 which can be changed by an application.
 
-@strong{Uses a byte-protocol} to communicate with the client,
+@strong{Uses a byte-protocol} to communicate with the back-end,
 so can run in a browser (using web sockets);
 be embedded in an application;
 or run as a standard terminal emulator application.
@@ -121,11 +121,11 @@ or run as a standard terminal emulator application.
 Optional @strong{input editing}.  In @dfn{character mode},
 each character is sent to the application, like a traditional terminal.
 In @dfn{line mode}, the browser does the editing, and send the input line
-to the client when Enter is typed.
+to the back-end when Enter is typed.
 A history of previous lines is available, accessible
 with the Up/Down arrow keys.
 @dfn{Automatic mode} switches between character mode and line mode
-depending on whether the client is in ``@uref{http://www.gnu.org/software/libc/manual/html_node/Canonical-or-Not.html,canonical mode}''.
+depending on whether the back-end is in ``@uref{http://www.gnu.org/software/libc/manual/html_node/Canonical-or-Not.html,canonical mode}''.
 
 @strong{Smart line-wrapping}: Remembers which lines were too wide (and thus
 were wrapped).  Window size re-size will automatically re-do line-breaking.
@@ -468,7 +468,7 @@ whose @code{class} is @code{domterm}.
 @item @var{domterm-toplevel} ::= @var{internal-div-elements} @var{block-content}@sup{*}
 
 You don't need to create @var{domterm-toplevel} - it is created and managed by
-DomTerm, based on data from the client.
+DomTerm, based on data from the back-end.
 
 Currently, the @var{block-content} is a single
 @code{<div class="interaction">}
@@ -546,7 +546,7 @@ escape sequences as understoof by bash's @code{echo -e}.
 Specifically @code{"\e"} is an escape; @code{"\a"} is alert (bell);
 @code{"\xHH"} is the 8-bit characters whose value is HH (hexadecimal).
 
-@section Special sequences sent by client and handled by DomTerm
+@section Special sequences sent by back-end and handled by DomTerm
 
 @table @asis
 @item @code{"\e]72;" @var{html-text} "\a"}
@@ -604,7 +604,7 @@ but the inferiors doesn't echo info, so we have to do it.
 This mode is useful when the input is a pipe or some other non-tty stream.
 @end table
 
-@section Special sequences sent by DomTerm to client
+@section Special sequences sent by DomTerm to back-end
 
 @table @asis
 @item @code{"\x92" @var{name} " " @var{data} "\n"}
@@ -614,13 +614,13 @@ The @var{data} can be any text not including a @code{"\n"}
 (or other control character); JSON format is used in some cases.
 
 @item @code{"\x92" "WS " @var{rows} " " @var{cols} " " @var{height} " " @var{width} "\n"}
-Report window size from DomTerm to the client.
+Report window size from DomTerm to the back-end.
 
 @item @code{"\x92" "KEY " @var{kcode} " " @var{kchars} "\n"}
-Used by auto-line mode to report a key event to client.
+Used by auto-line mode to report a key event to back-end.
 The @var{kcode} is a numeric key code,
 while @var{kchars} is as string literal (JSON-formatted)
-of the characters that are normally transmitted to the client.
+of the characters that are normally transmitted to the back-end.
 In auto-line mode, if the pty is in canonical mode, then @var{key}
 is returned to DomTerm (using @code{"\e]74;" @var{key} "\a"});
 otherwise @var{kchars} are sent to the pty.
@@ -665,7 +665,7 @@ the state of a terminal emulator / console.
 
 "Line" here refer to "visual line": A section of the DOM that should be
 treated as a line for cursor movement.  Line breaks may come from the
-client, or be inserted by the line break algorithm.
+back-end, or be inserted by the line break algorithm.
 
 The lineStarts array maps from a line number to the DOM location
 of the start of the corresponding line.

--- a/org/domterm/Backend.java
+++ b/org/domterm/Backend.java
@@ -3,11 +3,11 @@ package org.domterm;
 import org.domterm.util.Util;
 import java.io.*;
 
-/** Encapsulates a client (inferior) and how we communicate with it.
+/** Encapsulates a back-end (inferior) and how we communicate with it.
  * Does not encapsulate a front-end (GUI or browser) or transport layer.
  */
 
-public abstract class Client {
+public abstract class Backend {
     public int verbosity = 0;
 
     public String versionInfo;
@@ -26,7 +26,7 @@ public abstract class Client {
                     termWriter.write("\033]74;"+str+"\007");
                 } catch (IOException ex) {
                     if (verbosity > 0)
-                        System.err.println("PtyClient caught "+ex);        
+                        System.err.println("PtyBackend caught "+ex);        
                 }
             } else {
                 int q = str.indexOf('"');
@@ -64,7 +64,7 @@ public abstract class Client {
      */
     protected Writer termWriter;
 
-    /** Initialize and run this client.
+    /** Initialize and run this back-end.
      * @param out used to initialize termWriter - see note there.
      */
     public abstract void run(Writer out) throws Exception;

--- a/org/domterm/ClassBackend.java
+++ b/org/domterm/ClassBackend.java
@@ -5,23 +5,23 @@ import java.lang.reflect.Method;
 import java.io.*;
 import java.util.List;
 
-public class ClassClient extends Client {
+public class ClassBackend extends Backend {
 
     Method methodToRun;
     String[] restArgs;
     Writer pin;
 
-    public ClassClient(String className, String[] restArgs) throws Exception {
+    public ClassBackend(String className, String[] restArgs) throws Exception {
         this(getMainMethod(className), restArgs);
     }
 
-     public ClassClient(Method methodToRun, String[] restArgs) {
+     public ClassBackend(Method methodToRun, String[] restArgs) {
         this.methodToRun = methodToRun;
         this.restArgs = restArgs;
         lineEditingMode = 'l';
     }
 
-   public ClassClient(List<String> args) throws Exception {
+   public ClassBackend(List<String> args) throws Exception {
         this.methodToRun = getMainMethod(args.get(0));
         int nargs = args.size();
         this.restArgs = new String[nargs-1];

--- a/org/domterm/ProcessBackend.java
+++ b/org/domterm/ProcessBackend.java
@@ -9,7 +9,7 @@ import java.io.*;
  * hence no Console (TTY) is available.
  */
 
-public class ProcessClient extends Client {
+public class ProcessBackend extends Backend {
     Process process;
     private Writer pin;
     Reader pout;
@@ -19,11 +19,11 @@ public class ProcessClient extends Client {
     public static String[] defaultCommandWithArgs
         = {"bash", "--noediting", "-i" };
 
-    public ProcessClient() throws java.lang.Exception {
+    public ProcessBackend() throws java.lang.Exception {
         this(defaultCommandWithArgs);
     }
 
-    public ProcessClient(String[] commandWithArgs) throws java.lang.Exception {
+    public ProcessBackend(String[] commandWithArgs) throws java.lang.Exception {
         if (commandWithArgs.length == 0)
             commandWithArgs = defaultCommandWithArgs;
         this.commandWithArgs = commandWithArgs;

--- a/org/domterm/javafx/Main.java
+++ b/org/domterm/javafx/Main.java
@@ -17,8 +17,8 @@ public class Main {
         usage();
         System.exit(-1);
     }
-    static Client mainClient;
-    protected Client makeClient() throws java.lang.Exception {
+    static Backend mainClient;
+    protected Backend makeClient() throws java.lang.Exception {
         return mainClient;
     }
     public static void main(String[] args) {
@@ -32,14 +32,14 @@ public class Main {
                     usage("missing class name");
                 Method method = null;
                 try {
-                    method = ClassClient.getMainMethod(args[i+1]);
+                    method = ClassBackend.getMainMethod(args[i+1]);
                 } catch (Throwable ex) {
                     usage("caught "+ex);
                 }
                 System.err.println("found method "+method);
                 String[] restArgs = new String[args.length-i-2];
                 System.arraycopy(args, i+2, restArgs, 0, restArgs.length);
-                mainClient = new ClassClient(method, restArgs);
+                mainClient = new ClassBackend(method, restArgs);
                 break;
             } else if (arg.equals("--pty"))
                 mode = 'T';
@@ -67,9 +67,9 @@ public class Main {
             }
             try {
                 if (mode == 'S')
-                    mainClient = new ProcessClient(restArgs);
+                    mainClient = new ProcessBackend(restArgs);
                 else
-                    mainClient = new PtyClient(restArgs);
+                    mainClient = new PtyBackend(restArgs);
              } catch (Throwable ex) {
                  usage("caught "+ex);
              }

--- a/org/domterm/javafx/RunClass.java
+++ b/org/domterm/javafx/RunClass.java
@@ -6,17 +6,17 @@ import javafx.application.Application;
 
 public class RunClass extends WebTerminalApp
 {
-    protected Client makeClient() throws java.lang.Exception {
+    protected Backend makeClient() throws java.lang.Exception {
         if (mainClient != null)
             return mainClient;
-        return new ClassClient(getParameters().getRaw());
+        return new ClassBackend(getParameters().getRaw());
     }
 
     public static void main(String[] args) throws Throwable {
         org.domterm.util.WTDebug.init();
         String[] restArgs = new String[args.length-1];
         System.arraycopy(args, 1, restArgs, 0, restArgs.length);
-        mainClient = new ClassClient(args[0], restArgs);
+        mainClient = new ClassBackend(args[0], restArgs);
         exitOnStop = true;
         Application.launch(args);
     }

--- a/org/domterm/javafx/RunProcess.java
+++ b/org/domterm/javafx/RunProcess.java
@@ -7,9 +7,9 @@ import javafx.application.Application;
 
 public class RunProcess extends WebTerminalApp
 {
-    protected Client makeClient() throws java.lang.Exception {
+    protected Backend makeClient() throws java.lang.Exception {
         List<String> args = getParameters().getRaw();
-        return new ProcessClient(args.toArray(new String[args.size()]));
+        return new ProcessBackend(args.toArray(new String[args.size()]));
     }
 
     public static void main(String[] args) throws Throwable {

--- a/org/domterm/javafx/WebTerminal.java
+++ b/org/domterm/javafx/WebTerminal.java
@@ -62,7 +62,7 @@ public class WebTerminal extends VBox // FIXME should extend Control
                  org.w3c.dom.events.EventListener
                       /*implements KeyListener, ChangeListener*/ 
 {
-    public Client client;
+    public Backend backend;
     public void log(String str) { WTDebug.println(str); }
     
     WebView webView;
@@ -114,8 +114,8 @@ public class WebTerminal extends VBox // FIXME should extend Control
     Element inputLine;
 
     public void setWindowSize(int nrows, int ncols, int pixw, int pixh) {
-        if (client != null)
-            client.setWindowSize(nrows, ncols, pixw, pixh);
+        if (backend != null)
+            backend.setWindowSize(nrows, ncols, pixw, pixh);
     }
 
     protected void enter(KeyEvent ke) {
@@ -159,12 +159,12 @@ public class WebTerminal extends VBox // FIXME should extend Control
         //addInputLine();
     }
 
-    public void setClient(Client client) {
-        this.client = client;
+    public void setBackend(Backend backend) {
+        this.backend = backend;
     }
 
-    public WebTerminal(Client client) {
-        setClient(client);
+    public WebTerminal(Backend backend) {
+        setBackend(backend);
         webView = new WebView();
         webEngine = webView.getEngine();
         webEngine.getLoadWorker().stateProperty().addListener(new ChangeListener<State>() {
@@ -172,7 +172,7 @@ public class WebTerminal extends VBox // FIXME should extend Control
                     if (newValue == State.SUCCEEDED) {
                         initialize();
                         if (initialOutput != null) {
-                            if (client != null && client.verbosity > 0)
+                            if (backend != null && backend.verbosity > 0)
                                 WTDebug.println("WT.changed newV:"+newValue+" initial:"+initialOutput+" jsW:"+jsWebTerminal+" outB:"+jsWebTerminal.getMember("outputBefore"));
                             jsWebTerminal.call("insertString", initialOutput);
                             initialOutput = null;
@@ -205,7 +205,7 @@ public class WebTerminal extends VBox // FIXME should extend Control
      */
     protected String pageUrl() {
         String rname = USE_XHTML ? "repl.xml" : "repl.html";
-        java.net.URL rurl = Client.class.getResource(rname);
+        java.net.URL rurl = Backend.class.getResource(rname);
         if (rurl == null)
             throw new RuntimeException("no initial web page "+rname);
         return rurl.toString();
@@ -226,12 +226,12 @@ public class WebTerminal extends VBox // FIXME should extend Control
             Object tmp = webEngine.executeScript("makeDomTerm()");
             jsWebTerminal = (JSObject) tmp;
             jsWebTerminal.setMember("java", this);
-            jsWebTerminal.setMember("jclient", client);
+            jsWebTerminal.setMember("jclient", backend);
             Object versionInfo = jsWebTerminal.getMember("versionInfo");
             if (versionInfo != null)
-                client.addVersionInfo(versionInfo.toString());
+                backend.addVersionInfo(versionInfo.toString());
             webEngine.executeScript("initDomTerm()");
-            client.run(new WebWriter(this));
+            backend.run(new WebWriter(this));
         } catch (Exception ex) {
             ex.printStackTrace();
             throw new RuntimeException(ex);
@@ -239,8 +239,8 @@ public class WebTerminal extends VBox // FIXME should extend Control
     }
 
     public final void processInputCharacters(String text) {
-        if (client != null)
-            client.processInputCharacters(text);
+        if (backend != null)
+            backend.processInputCharacters(text);
     }
 
     private String initialOutput;
@@ -249,7 +249,7 @@ public class WebTerminal extends VBox // FIXME should extend Control
        Platform.runLater(new Runnable() {
                 public void run() {
                     //jsWebTerminal = (JSObject) webEngine.executeScript("webTerminal");
-                    if (client != null && client.verbosity > 0)
+                    if (backend != null && backend.verbosity > 0)
                         WTDebug.println("insertOutput/later jsW:"+jsWebTerminal+" str:"+WTDebug.toQuoted(str));
                     if (jsWebTerminal == null)
                         initialOutput = initialOutput == null ? str

--- a/org/domterm/javafx/WebTerminalApp.java
+++ b/org/domterm/javafx/WebTerminalApp.java
@@ -32,7 +32,7 @@
 
 package org.domterm.javafx;
 
-import org.domterm.Client;
+import org.domterm.Backend;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -121,7 +121,7 @@ public class WebTerminalApp extends Application
             });
 
 
-        if (console.client.lineEditingMode != 'p') {
+        if (console.backend.lineEditingMode != 'p') {
             Menu inputModeMenu = new Menu("input mode");
             ToggleGroup inputModeGroup = new ToggleGroup();
             RadioMenuItem charModeItem = new RadioMenuItem("character mode");
@@ -149,8 +149,8 @@ public class WebTerminalApp extends Application
         return scene;
     }
 
-    static Client mainClient;
-    protected Client makeClient() throws java.lang.Exception {
+    static Backend mainClient;
+    protected Backend makeClient() throws java.lang.Exception {
         if (mainClient == null)
             throw new RuntimeException("internal error - mainClient not set");
         return mainClient;

--- a/org/domterm/pty/PtyBackend.java
+++ b/org/domterm/pty/PtyBackend.java
@@ -33,7 +33,7 @@
 
 package org.domterm.pty;
 
-import org.domterm.Client;
+import org.domterm.Backend;
 import org.domterm.util.Util;
 import org.domterm.util.WTDebug;
 import java.io.*;
@@ -43,7 +43,7 @@ import java.io.*;
  * (Only natively available on Unix-like systems.)
  */
 
-public class PtyClient extends Client {
+public class PtyBackend extends Backend {
     public Writer pin;
     public Reader pout;
     public PTY pty;
@@ -51,11 +51,11 @@ public class PtyClient extends Client {
 
     static String[] defaultArgs = { "/bin/bash" };
 
-    public PtyClient() {
+    public PtyBackend() {
         this(null);
     }
 
-    public PtyClient(String[] childArgs) {
+    public PtyBackend(String[] childArgs) {
         if (childArgs == null || childArgs.length == 0)
             childArgs = defaultArgs;
         this.childArgs = childArgs;

--- a/org/domterm/pty/RunPty.java
+++ b/org/domterm/pty/RunPty.java
@@ -43,8 +43,8 @@ public class RunPty extends WebTerminalApp
 {
     static String[] commandArgs;
 
-    protected Client makeClient() {
-        return new PtyClient(commandArgs);
+    protected Backend makeClient() {
+        return new PtyBackend(commandArgs);
     }
 
     public static void main(String[] args) throws Throwable {


### PR DESCRIPTION
Client was ambiguous. It could easily refer to the client running as a browser
(the DomTerm) or a client being managed by the DomServer (like Kawa). The later
use is consistent with X11 applications, but confusing in general.

This commit does not touch any references to the HTML and JS. Those can come in
a separate commit.

Also, I have avoided touching the following in WebTerminal.java:

    jsWebTerminal.setMember("jclient", backend);

Since I didn't want to mess with any of the JS for now.