### PR TITLE
Support the CHROME_BIN environment variable (for those of us using Chromium on Debian/Ubuntu)

### DIFF
--- a/org/domterm/websocket/DomServer.java
+++ b/org/domterm/websocket/DomServer.java
@@ -247,6 +247,9 @@ public class DomServer extends WebSocketServer {
                 process.waitFor();
             } else if (runBrowser == 2) {
                 String chromeCommand = "google-chrome";
+                String chromeBin = System.getenv("CHROME_BIN");
+                if (chromeBin != null && new File(chromeBin).exists())
+                    chromeCommand = chromeBin;
                 String appArg = "--app=file://"+domtermPath+"/repl-client.html?ws=//localhost:"+port+"/";
                 System.err.println("call "+chromeCommand+" with "+appArg);
                 Process process = Runtime.getRuntime()


### PR DESCRIPTION
Some distros, like Debian-derived ones, ship Chromium as `/usr/bin/chromium-browser`.

While we could always add a symlink to `google-chrome` to work around this, this sort of solution is already used by, for example, Karma to allow you to specify explicitly what Chrome binary you want. (This is also where I borrowed the environment variable name from).

Another advantage of this approach is that if you have multiple versions of Chrome installed (Chromium and branded, stable and Canary, etc.) you can be explicit about which one you want to use this way.

