### PR TITLE
Ignore various autogenerated documentation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,11 @@ doc/index.html
 doc/Applications.html
 doc/Architecture-notes.html
 doc/DOM-structure.html
+doc/Downloading-and-building.html
 doc/Features.html
-doc/To_002ddo.html
+doc/Technical-documentation.html
+doc/The-DomTerm-JavaScript-class.html
+doc/To-do.html
 doc/Wire-byte-protocol.html
 doc/DomTerm.xml
 web/*.html


### PR DESCRIPTION
Running `make doc/index.html` also generates some other documentation files, but they aren't in the gitignore.