### PR TITLE
Ignore libpty.dylib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.class
 *.o
 libpty.so
+libpty.dylib
 *~
 build
 Makefile


### PR DESCRIPTION
This ignores a library that gets built on OS X.