### PR TITLE
configure.ac: Remove default value from --with-qtwebengine help text

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_ARG_WITH(javafx,
   AS_HELP_STRING(--with-javafx@<:@=jfxrt.jar@:>@,Enable support for JavaFX))
 
 AC_ARG_WITH(qtwebengine,
-  AS_HELP_STRING(--with-qtwebengine@<:@=jfxrt.jar@:>@,Build QtWebEngine front-end))
+  AS_HELP_STRING(--with-qtwebengine,Build QtWebEngine front-end))
 
 conf_classpath=
 echo host: $host


### PR DESCRIPTION
The `--with-qtwebengine` configure option had misleading help text, presumably the result of a copy-paste error.