### PR TITLE
dt-util: Use bash in shebang line

### DIFF
--- a/bin/dt-util
+++ b/bin/dt-util
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 help_general() {
   echo "dt-util: various utilities for working in DomTerm"


### PR DESCRIPTION
It contains a number of bashisms, causing it to fail
on Ubuntu where /bin/sh is dash.

Signed-off-by: Bob W. Hogg <rwhogg@linux.com>