### PR TITLE
fix electron command

### DIFF
--- a/lws-term/server.c
+++ b/lws-term/server.c
@@ -519,7 +519,7 @@ electron_command(struct options *options)
     }
     char *app = get_bin_relative_path(DOMTERM_DIR_RELATIVE "/electron");
     char *app_fixed = fix_for_windows(app);
-    char *format = "%s %s%s%s --url '%U'";
+    char *format = "%s %s%s%s --url '%%U'";
     const char *g1 = "", *g2 = "";
     char *geometry = geometry_option(options);
     if (geometry) {


### PR DESCRIPTION
Without this change, my electron command looks like:

    NOTICE: frontend command: .../Electron.app/Contents/MacOS/Electron .../share/domterm/electron --url '140372193848080' 'file:///.../.domterm/default.html#con...

I.e. `sprintf` replaces `%U` by some random integer.